### PR TITLE
Update models to Guide and Company

### DIFF
--- a/Admin/backend/main_firestore.py
+++ b/Admin/backend/main_firestore.py
@@ -45,8 +45,8 @@ app.add_middleware(
 )
 
 excursions_ref = db.collection("excursions")
-users_ref = db.collection("users")
-customers_ref = db.collection("customers")
+guides_ref = db.collection("guides")
+companies_ref = db.collection("companies")
 
 
 class Excursion(BaseModel):
@@ -61,17 +61,26 @@ class Excursion(BaseModel):
     type: str
 
 
-class User(BaseModel):
+class Guide(BaseModel):
     name: str
-    telegram: str
+    avatar: str
+    bio: str
+    createdAt: str
+    email: str
+    level: str
+    phone: str
+    telegramAlias: str
     excursionsDone: int
 
-class Customer(BaseModel):
+class Company(BaseModel):
+    address: str
     name: str
-    telegram: str
-    banList: list
+    createdAt: str
+    email: str
+    phone: str
+    banList: list[str]
 
-class CustomerOut(Customer):
+class CompanyOut(Company):
     id:str
 
 
@@ -79,49 +88,49 @@ class ExcursionOut(Excursion):
     id: str
 
 
-class UserOut(User):
+class GuideOut(Guide):
     id: str
 
 
-@app.get("/users", response_model=List[UserOut])
-def list_users():
-    docs = users_ref.stream()
-    return [UserOut(id=doc.id, **doc.to_dict()) for doc in docs]
+@app.get("/guides", response_model=List[GuideOut])
+def list_guides():
+    docs = guides_ref.stream()
+    return [GuideOut(id=doc.id, **doc.to_dict()) for doc in docs]
 
 
-@app.post("/users", response_model=UserOut)
-def create_user(user: User):
-    data = user.dict()
-    doc_ref = users_ref.document()
+@app.post("/guides", response_model=GuideOut)
+def create_guide(guide: Guide):
+    data = guide.dict()
+    doc_ref = guides_ref.document()
     doc_ref.set(data)
-    return UserOut(id=doc_ref.id, **data)
+    return GuideOut(id=doc_ref.id, **data)
 
 
-@app.get("/users/{user_id}", response_model=UserOut)
-def get_user(user_id: str):
-    doc = users_ref.document(user_id).get()
+@app.get("/guides/{guide_id}", response_model=GuideOut)
+def get_guide(guide_id: str):
+    doc = guides_ref.document(guide_id).get()
     if not doc.exists:
-        raise HTTPException(status_code=404, detail="User not found")
-    return UserOut(id=doc.id, **doc.to_dict())
+        raise HTTPException(status_code=404, detail="Guide not found")
+    return GuideOut(id=doc.id, **doc.to_dict())
 
 
-@app.put("/users/{user_id}", response_model=UserOut)
-def update_user(user_id: str, user: User):
-    doc_ref = users_ref.document(user_id)
+@app.put("/guides/{guide_id}", response_model=GuideOut)
+def update_guide(guide_id: str, guide: Guide):
+    doc_ref = guides_ref.document(guide_id)
     if not doc_ref.get().exists:
-        raise HTTPException(status_code=404, detail="User not found")
-    doc_ref.update(user.dict())
+        raise HTTPException(status_code=404, detail="Guide not found")
+    doc_ref.update(guide.dict())
     data = doc_ref.get().to_dict()
-    return UserOut(id=doc_ref.id, **data)
+    return GuideOut(id=doc_ref.id, **data)
 
 
-@app.delete("/users/{user_id}")
-def delete_user(user_id: str):
-    doc_ref = users_ref.document(user_id)
+@app.delete("/guides/{guide_id}")
+def delete_guide(guide_id: str):
+    doc_ref = guides_ref.document(guide_id)
     if not doc_ref.get().exists:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=404, detail="Guide not found")
     doc_ref.delete()
-    return {"message": "User deleted"}
+    return {"message": "Guide deleted"}
 
 
 @app.get("/excursions", response_model=List[ExcursionOut])
@@ -164,45 +173,45 @@ def delete_excursion(excursion_id: str):
     doc_ref.delete()
     return {"message": "Excursion deleted"}
 
-@app.get("/customers", response_model=List[CustomerOut])
-def list_customers():
-    docs = customers_ref.stream()
-    return [CustomerOut(id=doc.id, **doc.to_dict()) for doc in docs]
+@app.get("/companies", response_model=List[CompanyOut])
+def list_companies():
+    docs = companies_ref.stream()
+    return [CompanyOut(id=doc.id, **doc.to_dict()) for doc in docs]
 
 
-@app.post("/customers", response_model=CustomerOut)
-def create_customer(customer: Customer):
-    data = customer.dict()
-    doc_ref = customers_ref.document()
+@app.post("/companies", response_model=CompanyOut)
+def create_company(company: Company):
+    data = company.dict()
+    doc_ref = companies_ref.document()
     doc_ref.set(data)
-    return CustomerOut(id=doc_ref.id, **data)
+    return CompanyOut(id=doc_ref.id, **data)
 
 
-@app.get("/customers/{customer_id}", response_model=CustomerOut)
-def get_customer(customer_id: str):
-    doc = customers_ref.document(customer_id).get()
+@app.get("/companies/{company_id}", response_model=CompanyOut)
+def get_company(company_id: str):
+    doc = companies_ref.document(company_id).get()
     if not doc.exists:
-        raise HTTPException(status_code=404, detail="Customer not found")
-    return CustomerOut(id=doc.id, **doc.to_dict())
+        raise HTTPException(status_code=404, detail="Company not found")
+    return CompanyOut(id=doc.id, **doc.to_dict())
 
 
-@app.put("/customers/{customer_id}", response_model=CustomerOut)
-def update_customer(customer_id: str, customer: Customer):
-    doc_ref = customers_ref.document(customer_id)
+@app.put("/companies/{company_id}", response_model=CompanyOut)
+def update_company(company_id: str, company: Company):
+    doc_ref = companies_ref.document(company_id)
     if not doc_ref.get().exists:
-        raise HTTPException(status_code=404, detail="Customer not found")
-    doc_ref.update(customer.dict())
+        raise HTTPException(status_code=404, detail="Company not found")
+    doc_ref.update(company.dict())
     data = doc_ref.get().to_dict()
-    return CustomerOut(id=doc_ref.id, **data)
+    return CompanyOut(id=doc_ref.id, **data)
 
 
-@app.delete("/customers/{customer_id}")
-def delete_customer(customer_id: str):
-    doc_ref = customers_ref.document(customer_id)
+@app.delete("/companies/{company_id}")
+def delete_company(company_id: str):
+    doc_ref = companies_ref.document(company_id)
     if not doc_ref.get().exists:
-        raise HTTPException(status_code=404, detail="Customer not found")
+        raise HTTPException(status_code=404, detail="Company not found")
     doc_ref.delete()
-    return {"message": "Customer deleted"}
+    return {"message": "Company deleted"}
 
 @app.get("/api")  # Важно: должен быть зарегистрирован именно этот путь
 def read_api():

--- a/Admin/frontend/src/components/ManageUsersModal.tsx
+++ b/Admin/frontend/src/components/ManageUsersModal.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { useMutation, useQueryClient, useQuery } from 'react-query';
 import { X, User as UserIcon, MessageCircle } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
-import { createUser, CreateUserData, fetchUsers, User } from '../services/api';
+import { createGuide, CreateGuideData, fetchGuides, Guide } from '../services/api';
 import './ManageUsersModal.css';
 
 interface ManageUsersModalProps {
@@ -16,19 +16,28 @@ interface ManageUsersModalProps {
 const ManageUsersModal: React.FC<ManageUsersModalProps> = ({ open, onOpenChange }) => {
   const { t } = useLanguage();
   const queryClient = useQueryClient();
-  const { register, handleSubmit, reset, formState: { errors } } = useForm<CreateUserData>();
+  const { register, handleSubmit, reset, formState: { errors } } = useForm<CreateGuideData>();
 
-  const { data: users = [], isLoading } = useQuery('users', fetchUsers);
+  const { data: users = [], isLoading } = useQuery('guides', fetchGuides);
 
-  const createUserMutation = useMutation(createUser, {
+  const createUserMutation = useMutation(createGuide, {
     onSuccess: () => {
-      queryClient.invalidateQueries('users');
+      queryClient.invalidateQueries('guides');
       reset();
     }
   });
 
-  const onSubmit = (data: CreateUserData) => {
-    createUserMutation.mutate({ ...data, excursionsDone: Number(data.excursionsDone || 0) });
+  const onSubmit = (data: CreateGuideData) => {
+    createUserMutation.mutate({
+      ...data,
+      excursionsDone: Number(data.excursionsDone || 0),
+      avatar: data.avatar || '',
+      bio: data.bio || '',
+      createdAt: data.createdAt || new Date().toISOString(),
+      email: data.email || '',
+      level: data.level || '',
+      phone: data.phone || ''
+    });
   };
 
   if (!open) return null;
@@ -53,13 +62,13 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({ open, onOpenChange 
                 {users.length === 0 ? (
                   <p className="no-users">Ни одного гида в системе не зарешистрировано. Добавьте первого, заполнив форму</p>
                 ) : (
-                  users.map((user: User) => (
-                    <div key={user.id} className="user-item">
+                  users.map((guide: Guide) => (
+                    <div key={guide.id} className="user-item">
                       <div className="user-info">
-                        <h4>{user.name}</h4>
+                        <h4>{guide.name}</h4>
                         <div className="user-details">
-                          {user.telegram && <span><MessageCircle size={14} /> @{user.telegram}</span>}
-                          <span className="excursions-done">{user.excursionsDone} excursions</span>
+                          {guide.telegramAlias && <span><MessageCircle size={14} /> @{guide.telegramAlias}</span>}
+                          <span className="excursions-done">{guide.excursionsDone} excursions</span>
                         </div>
                       </div>
                     </div>
@@ -86,9 +95,9 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({ open, onOpenChange 
                   <label htmlFor="telegram">Телеграм</label>
                   <div className="input-with-icon">
                     <MessageCircle size={16} />
-                    <input id="telegram" {...register('telegram', { required: 'Введите телеграмм контакт гида' })} placeholder="telegram_username" />
+                    <input id="telegramAlias" {...register('telegramAlias', { required: 'Введите телеграмм контакт гида' })} placeholder="telegram_username" />
                   </div>
-                  {errors.telegram && <span className="error">{errors.telegram.message}</span>}
+                  {errors.telegramAlias && <span className="error">{errors.telegramAlias.message}</span>}
                 </div>
               </div>
 

--- a/Admin/frontend/src/pages/Dashboard.tsx
+++ b/Admin/frontend/src/pages/Dashboard.tsx
@@ -7,7 +7,7 @@ import CreateExcursionModal from '../components/CreateExcursionModal';
 import ManageUsersModal from '../components/ManageUsersModal';
 import Sidebar from '../components/Sidebar';
 import { useLanguage } from '../contexts/LanguageContext';
-import { fetchExcursions, fetchUsers, Excursion } from '../services/api';
+import { fetchExcursions, fetchGuides, Excursion } from '../services/api';
 import './Dashboard.css';
 
 export default function Dashboard() {
@@ -26,7 +26,7 @@ export default function Dashboard() {
     { refetchInterval: 30000 }
   );
 
-  const { data: users = [] } = useQuery('users', fetchUsers);
+  const { data: users = [] } = useQuery('guides', fetchGuides);
 
   const stats = {
     totalExcursions: excursions.length

--- a/Admin/frontend/src/services/api.ts
+++ b/Admin/frontend/src/services/api.ts
@@ -11,10 +11,16 @@ const api = axios.create({
   },
 });
 
-export interface User {
+export interface Guide {
   id: string;
   name: string;
-  telegram: string;
+  avatar: string;
+  bio: string;
+  createdAt: string;
+  email: string;
+  level: string;
+  phone: string;
+  telegramAlias: string;
   excursionsDone: number;
 }
 
@@ -30,23 +36,35 @@ export interface Excursion {
   time: string;
   type: string;
 }
-export interface Customer{
+export interface Company{
     id:string;
+    address: string;
     name: string;
-    telegram: string;
-    banList: Array<User>;
+    createdAt: string;
+    email: string;
+    phone: string;
+    banList: Array<string>;
 }
 
-export interface CreateUserData {
+export interface CreateGuideData {
   name: string;
-  telegram: string;
+  avatar: string;
+  bio: string;
+  createdAt: string;
+  email: string;
+  level: string;
+  phone: string;
+  telegramAlias: string;
   excursionsDone?: number;
 }
 
-export interface CreateCustomerData{
+export interface CreateCompanyData{
+  address: string;
   name: string;
-  telegram: string;
-  banList: Array<User>;
+  createdAt: string;
+  email: string;
+  phone: string;
+  banList: Array<string>;
 }
 
 export interface CreateExcursionData {
@@ -62,29 +80,29 @@ export interface CreateExcursionData {
 }
 
 //Customers
-export const fetchCustomers = async(): Promise<Customer[]> =>{
-  const response = await api.get('/customers');
+export const fetchCompanies = async(): Promise<Company[]> =>{
+  const response = await api.get('/companies');
   return response.data;
 };
 
-export const createCustomer = async (customerData: CreateCustomerData): Promise<Customer> => {
-  const response = await api.post('/customers', customerData);
+export const createCompany = async (companyData: CreateCompanyData): Promise<Company> => {
+  const response = await api.post('/companies', companyData);
   return response.data;
 };
 
-export const fetchCustomer = async(id: string): Promise<Customer> =>{
-  const response = await api.get(`/customers/${id}`);
+export const fetchCompany = async(id: string): Promise<Company> =>{
+  const response = await api.get(`/companies/${id}`);
   return response.data;
 };
 
-// Users
-export const fetchUsers = async (): Promise<User[]> => {
-  const response = await api.get('/users');
+// Guides
+export const fetchGuides = async (): Promise<Guide[]> => {
+  const response = await api.get('/guides');
   return response.data;
 };
 
-export const createUser = async (userData: CreateUserData): Promise<User> => {
-  const response = await api.post('/users', userData);
+export const createGuide = async (guideData: CreateGuideData): Promise<Guide> => {
+  const response = await api.post('/guides', guideData);
   return response.data;
 };
 

--- a/Admin/tests/test_admins.py
+++ b/Admin/tests/test_admins.py
@@ -89,23 +89,23 @@ def client(monkeypatch):
     client, _ = get_test_client(monkeypatch)
     return client
 
-def test_list_users_empty(client):
-    response = client.get('/users')
+def test_list_guides_empty(client):
+    response = client.get('/guides')
     assert response.status_code == 200
     assert response.json() == []
 
-def test_create_and_get_user(monkeypatch):
+def test_create_and_get_guide(monkeypatch):
     client, module = get_test_client(monkeypatch)
-    user_data = {'name': 'Alice', 'telegram': '@alice', 'excursionsDone': 0}
-    resp = client.post('/users', json=user_data)
+    guide_data = {'name': 'Alice', 'avatar': '', 'bio': '', 'createdAt': '', 'email': '', 'level': '', 'phone': '', 'telegramAlias': '@alice', 'excursionsDone': 0}
+    resp = client.post('/guides', json=guide_data)
     assert resp.status_code == 200
     created = resp.json()
     assert created['name'] == 'Alice'
-    user_id = created['id']
-    resp = client.get(f'/users/{user_id}')
+    guide_id = created['id']
+    resp = client.get(f'/guides/{guide_id}')
     assert resp.status_code == 200
-    assert resp.json()['telegram'] == '@alice'
+    assert resp.json()['telegramAlias'] == '@alice'
     # delete user and verify 404
-    client.delete(f'/users/{user_id}')
-    resp = client.get(f'/users/{user_id}')
+    client.delete(f'/guides/{guide_id}')
+    resp = client.get(f'/guides/{guide_id}')
     assert resp.status_code == 404

--- a/tour_guide_manager/lib/screens/applications.dart
+++ b/tour_guide_manager/lib/screens/applications.dart
@@ -18,13 +18,13 @@ class _ApplicationsState extends State<Applications> {
   @override
   void initState() {
     super.initState();
-    _loadCustomers();
+    _loadCompanies();
   }
 
-  Future<void> _loadCustomers() async {
+  Future<void> _loadCompanies() async {
     final firestore = FirebaseFirestore.instance;
     final userEmail = FirebaseAuth.instance.currentUser!.email!;
-    final snapshot = await firestore.collection('customers').get();
+    final snapshot = await firestore.collection('companies').get();
 
     final List<String> parsedCustomers = [];
     for (var doc in snapshot.docs) {

--- a/tour_guide_manager/lib/screens/auth/registration_screen.dart
+++ b/tour_guide_manager/lib/screens/auth/registration_screen.dart
@@ -75,12 +75,18 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
           .createUserWithEmailAndPassword(email: email, password: password);
 
       await FirebaseFirestore.instance
-          .collection('users')
+          .collection('guides')
           .doc(userCred.user!.uid)
           .set({
-        'telegram': tg,
+        'telegramAlias': tg,
         'excursionsDone': 0,
         'name': name,
+        'avatar': '',
+        'bio': '',
+        'createdAt': Timestamp.now(),
+        'email': email,
+        'level': '',
+        'phone': '',
       });
 
       if (mounted) {

--- a/tour_guide_manager/lib/screens/profile.dart
+++ b/tour_guide_manager/lib/screens/profile.dart
@@ -33,7 +33,7 @@ class Profile extends StatelessWidget {
       backgroundColor: const Color(0xffE6F2FF),
       body: StreamBuilder<DocumentSnapshot>(
         stream: FirebaseFirestore.instance
-            .collection('users')
+            .collection('guides')
             .doc(userId)
             .snapshots(),
         builder: (context, snapshot) {
@@ -88,7 +88,7 @@ class Profile extends StatelessWidget {
           }
           // Safe cast with null check
           final userData = snapshot.data!.data() as Map<String, dynamic>? ?? {};
-          final user = UserProfile.fromFirestore(userData);
+          final user = GuideProfile.fromFirestore(userData);
 
           return Center(
             child: Column(
@@ -134,18 +134,39 @@ class Profile extends StatelessWidget {
   }
 }
 
-class UserProfile {
+class GuideProfile {
   final String name;
-  final int excursionsDone; // Changed to int
+  final String avatar;
+  final String bio;
+  final DateTime createdAt;
+  final String email;
+  final String level;
+  final String phone;
+  final String telegramAlias;
+  final int excursionsDone;
 
-  UserProfile({
+  GuideProfile({
     required this.name,
+    required this.avatar,
+    required this.bio,
+    required this.createdAt,
+    required this.email,
+    required this.level,
+    required this.phone,
+    required this.telegramAlias,
     required this.excursionsDone,
   });
 
-  factory UserProfile.fromFirestore(Map<String, dynamic> data) {
-    return UserProfile(
+  factory GuideProfile.fromFirestore(Map<String, dynamic> data) {
+    return GuideProfile(
       name: data['name']?.toString() ?? 'Имя не указано',
+      avatar: data['avatar']?.toString() ?? '',
+      bio: data['bio']?.toString() ?? '',
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+      email: data['email']?.toString() ?? '',
+      level: data['level']?.toString() ?? '',
+      phone: data['phone']?.toString() ?? '',
+      telegramAlias: data['telegramAlias']?.toString() ?? '',
       excursionsDone: (data['excursionsDone'] as int?) ?? 0,
     );
   }


### PR DESCRIPTION
## Summary
- switch firestore collections from `users`/`customers` to `guides`/`companies`
- update backend models and API endpoints for new `Guide` and `Company` schema
- adjust frontend API client and manage users modal for guides
- update dashboard to fetch guides
- adapt registration/profile/application screens in Flutter app
- update tests for new endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6872453d38ec8329947eece8c5e98e86